### PR TITLE
Updated links to UI scene graph elements in the Containers, Controls,…

### DIFF
--- a/_docs/scene-graph/nodes.md
+++ b/_docs/scene-graph/nodes.md
@@ -3,13 +3,13 @@ title: Nodes
 permalink: /docs/scene-graph/nodes
 ---
 
-There are three main implementations of nodes in the scene graph that LittleKt offers. Those three are the base [Node](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/Node.kt), a 2D-based node [Node2D](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/Node2D.kt), and the user interface module of nodes. We will be reviewing `Node` and `Node2D` here. Check out [The User Interface](/docs/ui/the-user-interface) if you want to learn more on the UI.
+There are three main implementations of nodes in the scene graph that LittleKt offers. Those three are the base [Node](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/Node.kt), a 2D-based node [Node2D](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/node2d/Node2D.kt), and the user interface module of nodes. We will be reviewing `Node` and `Node2D` here. Check out [The User Interface](/docs/ui/the-user-interface) if you want to learn more on the UI.
 
 ## Node
 
 The `Node` contains the base implementation that is used by all nodes in a scene graph. This contains lifecycle methods, render methods, adding/removing children, and any hierarchy changes.
 
-A `Node` can contain one or more [Signal](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/util/signals.kt) types which can be used to subscribe to certain events that the node can emit.
+A `Node` can contain one or more [Signal](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/util/signals.kt) types which can be used to subscribe to certain events that the node can emit.
 
 For example, the `Node` class contains the following signals:
 
@@ -164,7 +164,7 @@ node2d {
 
 ### Material
 
-A `CanvasItem` contains [Material](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/render/Material.kt) instance that can be used to set shaders, blend modes, and depth/stencil modes. The `SceneGraph` handles any changes of the material of a `CanvasItem` which will flush the current batch thus increasing by a draw call.
+A `CanvasItem` contains [Material](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/render/Material.kt) instance that can be used to set shaders, blend modes, and depth/stencil modes. The `SceneGraph` handles any changes of the material of a `CanvasItem` which will flush the current batch thus increasing by a draw call.
 
 ```kotlin
 node2d {

--- a/_docs/ui/containers.md
+++ b/_docs/ui/containers.md
@@ -5,13 +5,13 @@ permalink: /docs/ui/containers
 
 Using [anchors](/docs/ui/size-and-anchors) can be efficient enough to handle multiple resolutions. But as the UI gets more complex, they become difficult to use.
 
-A way we can handle more complex and advanced layouts is by making use of [Containers](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Container.kt).
+A way we can handle more complex and advanced layouts is by making use of [Containers](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Container.kt).
 
 ## Container Layout
 
-When a [Container](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Container.kt) node is used, any [Control](<[Containers](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Control.kt)>) nodes that are a child give up their ability to position themselves. The parent container will handle all of these nodes position and sizes. Manually changing the child nodes position or size will either be ignored or invalidated the next time the parent is resized.
+When a [Container](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Container.kt) node is used, any [Control](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Control.kt) nodes that are a child give up their ability to position themselves. The parent container will handle all of these nodes position and sizes. Manually changing the child nodes position or size will either be ignored or invalidated the next time the parent is resized.
 
-When a container is resizes, all of its children are reositioned and resized as well:
+When a container is resizes, all of its children are repositioned and resized as well:
 
 ![hBox container resize example](/assets/images/ui/hbox-container-resize.gif)
 
@@ -51,7 +51,7 @@ There are several out of the box container types:
 
 #### HBox
 
-Arranges child controls horizontally while expanding vertically (via [HBoxContainer](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/HBoxContainer.kt)).
+Arranges child controls horizontally while expanding vertically (via [HBoxContainer](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/HBoxContainer.kt)).
 
 ![hBox container example](/assets/images/ui/hbox-example.png)
 
@@ -93,7 +93,7 @@ row {
 
 #### VBox
 
-Arranges child controls vertically while expanding horizontally (via [VBoxContainer](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/VBoxContainer.kt))
+Arranges child controls vertically while expanding horizontally (via [VBoxContainer](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/VBoxContainer.kt))
 
 ![vBox container example](/assets/images/ui/vbox-example.png)
 
@@ -134,7 +134,7 @@ column {
 
 ### Center Container
 
-Arranges child controls directly in the center (via [CenterContainer](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/CenterContainer.kt)).
+Arranges child controls directly in the center (via [CenterContainer](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/CenterContainer.kt)).
 
 ![center container example](/assets/images/ui/center-container-example.png)
 
@@ -151,7 +151,7 @@ centerContainer {
 
 ### Padded Container
 
-Arranges child controls that are expanded toward the bounds (via [PaddedContainer](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/PaddedContainer.kt)) with an additional padding that will be added to the margins which can be configured by the theme.
+Arranges child controls that are expanded toward the bounds (via [PaddedContainer](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PaddedContainer.kt)) with an additional padding that will be added to the margins which can be configured by the theme.
 
 ![padded container example](/assets/images/ui/padded-container-example.png)
 
@@ -167,7 +167,7 @@ paddedContainer {
 
 ### Panel Container
 
-A container that renders a _Drawable_ and expands its children to cover the whole area (via [PanelContainer](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/PanelContainer.kt)).
+A container that renders a _Drawable_ and expands its children to cover the whole area (via [PanelContainer](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PanelContainer.kt)).
 
 ![panel container example](/assets/images/ui/panel-container-example.png)
 

--- a/_docs/ui/controls.md
+++ b/_docs/ui/controls.md
@@ -3,7 +3,7 @@ title: Controls
 permalink: /docs/ui/controls
 ---
 
-A [Control](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Control.kt) is the base node that all UI related nodes are inherited from. The `Control` node handles all the functionality for updating anchors, margins, and sizes based on its parent control or the viewport. For more information on how anchors and sizes work check out the [Size and Anchors](/docs/ui/size-and-anchors) page.
+A [Control](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Control.kt) is the base node that all UI related nodes are inherited from. The `Control` node handles all the functionality for updating anchors, margins, and sizes based on its parent control or the viewport. For more information on how anchors and sizes work check out the [Size and Anchors](/docs/ui/size-and-anchors) page.
 
 ## Using a Control
 
@@ -31,7 +31,7 @@ The following list will only include non-container controls. For a list of conta
 
 ### Base Control
 
-The base control (via [Control](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Control.kt)). Contains no renderable components.
+The base control (via [Control](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Control.kt)). Contains no renderable components.
 
 ```kotlin
 control {
@@ -41,7 +41,7 @@ control {
 
 ### Button
 
-A standard themed button (via [Button](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Button.kt)) that can contain text and is displayed according to the `Theme`.
+A standard themed button (via [Button](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Button.kt)) that can contain text and is displayed according to the `Theme`.
 
 ```kotlin
 button {
@@ -55,7 +55,7 @@ button {
 
 ### Label
 
-Displays plain text (via [Label](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Label.kt)). Allows control of the horizontal and vertical alignments.
+Displays plain text (via [Label](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Label.kt)). Allows control of the horizontal and vertical alignments.
 
 ```kotlin
 label {
@@ -67,7 +67,7 @@ label {
 
 ### LineEdit
 
-Renders and a single line of editable text (via [LineEdit](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/LineEdit.kt)).
+Renders and a single line of editable text (via [LineEdit](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/LineEdit.kt)).
 
 Contains commonly built in shortcuts:
 
@@ -92,7 +92,7 @@ lineEdit {
 
 ### NinePatchRect
 
-Creates a ninepatch by slicing up the texture into nine patches (via [NinePatchRect](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/NinePatchRect.kt)) which produces clean panels of any size, based on a small texture by splitting it into a 3x3 grid. The drawn, the texture tiles the textures sides horizontally or vertically and the center on both axes but doesn't scale or tile the corners.
+Creates a ninepatch by slicing up the texture into nine patches (via [NinePatchRect](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/NinePatchRect.kt)) which produces clean panels of any size, based on a small texture by splitting it into a 3x3 grid. The drawn, the texture tiles the textures sides horizontally or vertically and the center on both axes but doesn't scale or tile the corners.
 
 ```kotlin
 ninePatchRect {
@@ -106,7 +106,7 @@ ninePatchRect {
 
 ### Panel
 
-Displays an opaque background (via [Panel](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Panel.kt)). Commonly used as a parent.
+Displays an opaque background (via [Panel](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Panel.kt)). Commonly used as a parent.
 
 ```kotlin
 panel {
@@ -118,7 +118,7 @@ panel {
 
 ### ProgressBar
 
-Generic progress bar / slider (via [ProgressBar](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/ProgressBar.kt)) that shows the fill percentage from left to right.
+Generic progress bar / slider (via [ProgressBar](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ProgressBar.kt)) that shows the fill percentage from left to right.
 
 ```kotlin
 progressBar {
@@ -128,7 +128,7 @@ progressBar {
 
 ### TextureProgress
 
-A textured-based progress bar (via [TextureProgress](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/TextureProgress.kt)). Useful for loading screens and health bars.
+A textured-based progress bar (via [TextureProgress](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureProgress.kt)). Useful for loading screens and health bars.
 
 ```kotlin
 textureProgress {
@@ -142,14 +142,14 @@ textureProgress {
 
 ### TextureRect
 
-Draws a texture slice (via [TextureRect](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/TextureRect.kt)). It can scale, tile, and keep centered inside its bounding box.
+Draws a texture slice (via [TextureRect](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureRect.kt)). It can scale, tile, and keep centered inside its bounding box.
 
 ```kotlin
 textureRect {
     slice = myTextureSlice
     stretchMode = TextureRect.StretchMode.TILE
 
-    // this is false by default. Useful for positiong the TextureSlice based off the oringal size before packing and trimming.
+    // this is false by default. Useful for positioning the TextureSlice based off the original size before packing and trimming.
     useOriginalSize = true
 }
 ```
@@ -181,7 +181,7 @@ We need to ensure we set the `_internalMinWidth` and `_internalMinHeight` proper
 
 ```kotlin
 override fun calculateMinSize() {
-    // we should ensure we check minSizeInvalid is false then we don't want to recaculate
+    // we should ensure we check minSizeInvalid is false then we don't want to recalculate
     // doing so will just waste resources
     if (!minSizeInvalid) return
 

--- a/_docs/ui/themes.md
+++ b/_docs/ui/themes.md
@@ -3,7 +3,7 @@ title: Themes
 permalink: /docs/ui/themes
 ---
 
-While we can set certain properties of a [Control](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/Control.kt) node to make it look the way we want, and in some cases it is easier, it can get difficult to handle when dealing with more advanced layouts and could be difficult to refactor.
+While we can set certain properties of a [Control](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Control.kt) node to make it look the way we want, and in some cases it is easier, it can get difficult to handle when dealing with more advanced layouts and could be difficult to refactor.
 
 Instead we can use a [Theme](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/component/Theme.kt) that handles rendering the correct drawables, colors, fonts, and even sizes. If you have used a _Control_ nodes that renders something to the screen then you have already used a theme without knowing it.
 
@@ -184,7 +184,7 @@ Theme(
 
 ### Theme Map Types
 
-Each theme expects a map of [Drawables](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/component/Drawable.kt), [Bitmap Fonts](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/font/BitmapFont.kt), [Colors](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graphics/Color.kt), and _Constants_.
+Each theme expects a map of [Drawables](https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/Drawable.kt), [Bitmap Fonts](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/font/BitmapFont.kt), [Colors](https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graphics/Color.kt), and _Constants_.
 
 Each of these maps are mapped to a _String_ to another map of the specified types. For example, the _drawables_ map expects a _String_ that maps to another map of _String_ that maps to a _Drawable_.
 


### PR DESCRIPTION
… Nodes and Themes documentation pages.

The URLs have been updated from https://github.com/littlektframework/littlekt/blob/master/core/src/commonMain/kotlin/com/littlekt/graph/node/node2d/ui/ to https://github.com/littlektframework/littlekt/blob/master/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ paths.

Fixed three small spelling errors.